### PR TITLE
docs: add IA and user flow diagrams

### DIFF
--- a/docs/IA.mmd
+++ b/docs/IA.mmd
@@ -1,0 +1,39 @@
+%% MAR PWA Information Architecture
+%% Themes: light/dark; base typography 16-18px with 24-28px headers; WCAG AA+ contrast.
+%% Safe-area: use env(safe-area-inset-*) padding to protect content from gestures.
+graph TD
+    AppShell[App Shell]
+    NavMobile[Mobile: AppBar + Drawer]
+    NavDesktop[Desktop: Sidebar]
+    AppShell --> NavMobile
+    AppShell --> NavDesktop
+
+    AppShell --> Home[Главная]
+    AppShell --> MyStudies[Мои исследования]
+    AppShell --> Profile[Профиль]
+    AppShell --> Rewards[Награды]
+    AppShell --> Support[Поддержка]
+
+    %% States
+    Home --> HLoading[loading]
+    Home --> HEmpty[empty]
+    Home --> HError[error]
+
+    MyStudies --> SLoading[loading]
+    MyStudies --> SEmpty[empty]
+    MyStudies --> SError[error]
+
+    Profile --> PLoading[loading]
+    Profile --> PEmpty[empty]
+    Profile --> PError[error]
+
+    Rewards --> RLoading[loading]
+    Rewards --> REmpty[empty]
+    Rewards --> RError[error]
+
+    Support --> SupLoading[loading]
+    Support --> SupEmpty[empty]
+    Support --> SupError[error]
+
+    SafeArea[Safe-area inset applied]
+    AppShell --- SafeArea

--- a/docs/flows.mmd
+++ b/docs/flows.mmd
@@ -1,0 +1,42 @@
+%% MAR PWA Main Flows
+%% Themes: light/dark; base typography 16-18px with 24-28px headers; WCAG AA+ contrast.
+%% Navigation adapts: Drawer on mobile, Sidebar on desktop. Safe-area insets protect content.
+flowchart TD
+    Start((Start))
+    Onboard[Welcome & Consent]
+    Profile[Profile]
+    Prescreen[Prescreen]
+    Invitations[Invitations Feed]
+    Survey[Survey Iframe]
+    Rewards[Rewards]
+
+    Start --> Onboard
+    Onboard --> Profile
+    Profile --> Prescreen
+    Prescreen --> Invitations
+    Invitations --> Survey
+    Survey --> Rewards
+
+    %% States for key steps
+    Onboard --> OnboardLoading[loading]
+    Onboard --> OnboardEmpty[empty]
+    Onboard --> OnboardError[error]
+
+    Profile --> ProfileLoading[loading]
+    Profile --> ProfileEmpty[empty]
+    Profile --> ProfileError[error]
+
+    Invitations --> InvLoading[loading]
+    Invitations --> InvEmpty[empty]
+    Invitations --> InvError[error]
+
+    Survey --> SurveyLoading[loading]
+    Survey --> SurveyEmpty[empty]
+    Survey --> SurveyError[error]
+
+    Rewards --> RewardsLoading[loading]
+    Rewards --> RewardsEmpty[empty]
+    Rewards --> RewardsError[error]
+
+    NavNote[Adaptive navigation & safe-area applied]
+    Start --- NavNote


### PR DESCRIPTION
## Summary
- map app screens with state nodes for loading/empty/error
- document main respondent flows with adaptive navigation notes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8f55eeb483308f80be7d6296c34b