### PR TITLE
feat: add initial postgres schema and ER diagram

### DIFF
--- a/docs/ER.md
+++ b/docs/ER.md
@@ -1,0 +1,17 @@
+# ER Diagram
+
+```mermaid
+erDiagram
+    USERS ||--o{ PROFILES : has
+    USERS ||--o{ CONSENTS : gives
+    USERS ||--o{ PRESCREENER_ANSWERS : answers
+    USERS ||--o{ DEVICE_SUBSCRIPTIONS : owns
+    USERS ||--o{ AUDIT_EVENTS : triggers
+    USERS ||--o{ INVITATIONS : receives
+    USERS ||--o{ PARTICIPATIONS : participates
+    USERS ||--o{ REWARDS : earns
+    STUDIES ||--o{ INVITATIONS : includes
+    STUDIES ||--o{ PARTICIPATIONS : includes
+    STUDIES ||--o{ REWARDS : awards
+    INVITATIONS ||--o{ PARTICIPATIONS : leads_to
+```

--- a/services/api/migrations/001_init.sql
+++ b/services/api/migrations/001_init.sql
@@ -1,0 +1,153 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Users
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_users_created_at ON users(created_at);
+CREATE INDEX idx_users_status_active ON users(status) WHERE status = 'active';
+
+-- Profiles
+CREATE TABLE IF NOT EXISTS profiles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT,
+    age INT,
+    gender TEXT,
+    city TEXT,
+    profession TEXT,
+    contacts JSONB,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_profiles_user_id ON profiles(user_id);
+CREATE INDEX idx_profiles_created_at ON profiles(created_at);
+CREATE INDEX idx_profiles_status_active ON profiles(status) WHERE status = 'active';
+
+-- Consents
+CREATE TABLE IF NOT EXISTS consents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type TEXT NOT NULL,
+    version TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'given',
+    given_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_consents_user_id ON consents(user_id);
+CREATE INDEX idx_consents_created_at ON consents(created_at);
+CREATE INDEX idx_consents_status_given ON consents(status) WHERE status = 'given';
+
+-- Prescreener Answers
+CREATE TABLE IF NOT EXISTS prescreener_answers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    question TEXT NOT NULL,
+    answer TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_prescreener_answers_user_id ON prescreener_answers(user_id);
+CREATE INDEX idx_prescreener_answers_created_at ON prescreener_answers(created_at);
+CREATE INDEX idx_prescreener_answers_status_active ON prescreener_answers(status) WHERE status = 'active';
+
+-- Studies
+CREATE TABLE IF NOT EXISTS studies (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title TEXT NOT NULL,
+    description TEXT,
+    reward NUMERIC(10,2),
+    status TEXT NOT NULL DEFAULT 'draft',
+    starts_at TIMESTAMPTZ,
+    ends_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_studies_created_at ON studies(created_at);
+CREATE INDEX idx_studies_status_active ON studies(status) WHERE status = 'active';
+
+-- Invitations
+CREATE TABLE IF NOT EXISTS invitations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    study_id UUID NOT NULL REFERENCES studies(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'pending',
+    sent_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    responded_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_invitations_study_user ON invitations(study_id, user_id);
+CREATE INDEX idx_invitations_created_at ON invitations(created_at);
+CREATE INDEX idx_invitations_status_pending ON invitations(status) WHERE status = 'pending';
+
+-- Participations
+CREATE TABLE IF NOT EXISTS participations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    study_id UUID NOT NULL REFERENCES studies(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'pending',
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_participations_created_at ON participations(created_at);
+CREATE INDEX idx_participations_status_pending ON participations(status) WHERE status = 'pending';
+
+-- Rewards
+CREATE TABLE IF NOT EXISTS rewards (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    study_id UUID REFERENCES studies(id) ON DELETE SET NULL,
+    amount NUMERIC(10,2) NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    issued_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_rewards_user_id ON rewards(user_id);
+CREATE INDEX idx_rewards_created_at ON rewards(created_at);
+CREATE INDEX idx_rewards_status_pending ON rewards(status) WHERE status = 'pending';
+
+-- Device Subscriptions
+CREATE TABLE IF NOT EXISTS device_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    endpoint TEXT NOT NULL,
+    p256dh TEXT,
+    auth TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_device_subscriptions_endpoint ON device_subscriptions(endpoint);
+CREATE INDEX idx_device_subscriptions_created_at ON device_subscriptions(created_at);
+CREATE INDEX idx_device_subscriptions_status_active ON device_subscriptions(status) WHERE status = 'active';
+
+-- Audit Events
+CREATE TABLE IF NOT EXISTS audit_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    action TEXT NOT NULL,
+    metadata JSONB,
+    status TEXT NOT NULL DEFAULT 'info',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_audit_events_user_id ON audit_events(user_id);
+CREATE INDEX idx_audit_events_created_at ON audit_events(created_at);
+CREATE INDEX idx_audit_events_status_info ON audit_events(status) WHERE status = 'info';


### PR DESCRIPTION
## Summary
- define initial PostgreSQL schema for core entities with status and timestamp indexes
- add ER diagram describing relationships

## Testing
- `su postgres -c "psql -v ON_ERROR_STOP=1 -f services/api/migrations/001_init.sql"`


------
https://chatgpt.com/codex/tasks/task_e_689c91b2196c8330993ad1db92196f25