### PR TITLE
chore: add ci workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,19 @@
+# CI/CD Workflow
+
+Этот репозиторий использует GitHub Actions для проверки и деплоя.
+
+## Последовательность
+1. **lint** – `npm run lint`
+2. **typecheck** – `npm run typecheck`
+3. **build** – `npm run build`
+4. **Lighthouse CI** – проверяет, что PWA, Performance и Best Practices ≥ 90.
+5. **deploy-web** – публикация `apps/web/dist` в GitHub Pages.
+6. **deploy-api** – триггер деплоя `services/api` в Render и Vercel.
+
+## Секреты окружения
+Добавьте в настройках репозитория:
+- `LHCI_GITHUB_TOKEN` – токен для Lighthouse CI.
+- `RENDER_API_TOKEN`, `RENDER_SERVICE_ID` – доступ к Render Deploy API.
+- `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` – параметры Vercel CLI.
+
+GitHub Pages использует встроенный `GITHUB_TOKEN`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  typecheck:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
+  build:
+    needs: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: web-dist
+          path: apps/web/dist
+
+  lighthouse:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: web-dist
+          path: dist
+      - name: Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v10
+        env:
+          LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
+        with:
+          config: |
+            {
+              "ci": {
+                "collect": { "staticDistDir": "dist" },
+                "assert": {
+                  "assertions": {
+                    "categories:pwa": ["error", { "minScore": 0.9 }],
+                    "categories:performance": ["error", { "minScore": 0.9 }],
+                    "categories:best-practices": ["error", { "minScore": 0.9 }]
+                  }
+                }
+              }
+            }
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+
+  deploy-web:
+    needs: lighthouse
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: web-dist
+          path: dist
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@v4
+
+  deploy-api:
+    needs: lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Deploy to Render
+        if: ${{ secrets.RENDER_API_TOKEN && secrets.RENDER_SERVICE_ID }}
+        env:
+          RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          curl -X POST https://api.render.com/deploy/srv-$RENDER_SERVICE_ID \
+            -H "Authorization: Bearer $RENDER_API_TOKEN"
+      - name: Deploy to Vercel
+        if: ${{ secrets.VERCEL_TOKEN && secrets.VERCEL_ORG_ID && secrets.VERCEL_PROJECT_ID }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          npm i -g vercel@latest
+          vercel deploy services/api --prod --yes \
+            --token $VERCEL_TOKEN \
+            --scope $VERCEL_ORG_ID \
+            --project $VERCEL_PROJECT_ID


### PR DESCRIPTION
## Summary
- add GitHub Actions CI pipeline with lint, typecheck, build, Lighthouse, and deployments
- document CI/CD secrets and job order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c91cafe7883309eaf8ffdb3dc94f6