### PR TITLE
feat(web): add studies feed

### DIFF
--- a/apps/web/src/components/StudyCard.tsx
+++ b/apps/web/src/components/StudyCard.tsx
@@ -1,0 +1,55 @@
+import { Study } from '../types';
+
+interface Props {
+  study: Study;
+  onOpen: (id: number) => void;
+  onStart: (id: number) => void;
+  onFinish: (id: number) => void;
+}
+
+const statusLabels: Record<Study['status'], string> = {
+  sent: 'Новое',
+  opened: 'Открыто',
+  started: 'В процессе',
+  finished: 'Завершено',
+};
+
+export default function StudyCard({ study, onOpen, onStart, onFinish }: Props) {
+  return (
+    <div
+      onClick={() => onOpen(study.id)}
+      style={{
+        border: '1px solid #ccc',
+        padding: '1rem',
+        marginBottom: '1rem',
+        cursor: 'pointer',
+      }}
+    >
+      <h3>{study.topic}</h3>
+      <p>Длительность: {study.duration} мин</p>
+      <p>Вознаграждение: {study.reward} ₽</p>
+      <p>Дедлайн: {study.deadline}</p>
+      <p>Статус: {statusLabels[study.status]}</p>
+      {(study.status === 'sent' || study.status === 'opened') && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onStart(study.id);
+          }}
+        >
+          Принять участие
+        </button>
+      )}
+      {study.status === 'started' && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onFinish(study.id);
+          }}
+        >
+          Завершить
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,4 @@
+export function trackEvent(event: string, payload: Record<string, unknown>) {
+  // TODO: replace console.log with real analytics implementation
+  console.log('analytics', event, payload);
+}

--- a/apps/web/src/pages/Studies.tsx
+++ b/apps/web/src/pages/Studies.tsx
@@ -1,3 +1,96 @@
+import { useEffect, useState } from 'react';
+import StudyCard from '../components/StudyCard';
+import { Study, StudyStatus } from '../types';
+import { trackEvent } from '../lib/analytics';
+
+const initialStudies: Study[] = [
+  {
+    id: 1,
+    topic: 'UX интервью',
+    duration: 30,
+    reward: 500,
+    deadline: '2024-12-31',
+    status: 'sent',
+  },
+  {
+    id: 2,
+    topic: 'Тестирование прототипа',
+    duration: 15,
+    reward: 300,
+    deadline: '2024-11-30',
+    status: 'sent',
+  },
+];
+
 export default function Studies() {
-  return <h2>Исследования</h2>;
+  const [filter, setFilter] = useState<'all' | StudyStatus>('all');
+  const [studies, setStudies] = useState<Study[]>(initialStudies);
+
+  // отправляем события приглашений один раз при инициализации
+  useEffect(() => {
+    studies.forEach((study) => trackEvent('invite_sent', { id: study.id }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleOpen = (id: number) => {
+    const study = studies.find((s) => s.id === id);
+    if (study && study.status === 'sent') {
+      trackEvent('invite_opened', { id });
+      setStudies((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, status: 'opened' } : s)),
+      );
+    }
+  };
+
+  const handleStart = (id: number) => {
+    const study = studies.find((s) => s.id === id);
+    if (study && study.status === 'sent') {
+      trackEvent('invite_opened', { id });
+    }
+    trackEvent('invite_started', { id });
+    setStudies((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, status: 'started' } : s)),
+    );
+  };
+
+  const handleFinish = (id: number) => {
+    trackEvent('invite_finished', { id });
+    setStudies((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, status: 'finished' } : s)),
+    );
+  };
+
+  const filtered = studies.filter((s) =>
+    filter === 'all' ? true : s.status === filter,
+  );
+
+  return (
+    <div>
+      <h2>Исследования</h2>
+      <label>
+        Фильтр:{' '}
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value as 'all' | StudyStatus)}
+        >
+          <option value="all">Все</option>
+          <option value="sent">Новые</option>
+          <option value="opened">Открытые</option>
+          <option value="started">В процессе</option>
+          <option value="finished">Завершённые</option>
+        </select>
+      </label>
+      <div>
+        {filtered.map((study) => (
+          <StudyCard
+            key={study.id}
+            study={study}
+            onOpen={handleOpen}
+            onStart={handleStart}
+            onFinish={handleFinish}
+          />
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,0 +1,10 @@
+export type StudyStatus = 'sent' | 'opened' | 'started' | 'finished';
+
+export interface Study {
+  id: number;
+  topic: string;
+  duration: number; // minutes
+  reward: number; // currency units
+  deadline: string; // ISO date string
+  status: StudyStatus;
+}


### PR DESCRIPTION
## Summary
- implement studies feed with cards, filters, and CTA
- add analytics tracking for invite status changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c998c3d748330a5dcac81ae15b3b5