### PR TITLE
feat(admin): audience segments and export

### DIFF
--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -31,6 +31,20 @@ export interface paths {
     /** Export invitations CSV */
     get: operations["exportInvitations"];
   };
+  "/api/audience": {
+    /** Search audience */
+    get: operations["searchAudience"];
+  };
+  "/api/segments": {
+    /** List segments */
+    get: operations["listSegments"];
+    /** Create segment */
+    post: operations["createSegment"];
+  };
+  "/api/segments/{id}/export": {
+    /** Export segment CSV */
+    get: operations["exportSegment"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -62,6 +76,24 @@ export interface components {
     };
     LaunchInvitationResponseDto: {
       launched: number;
+    };
+    ParticipantDto: {
+      id: string;
+      attributes?: {
+        [key: string]: string;
+      };
+      prescreen?: {
+        [key: string]: string;
+      };
+    };
+    CreateSegmentDto: {
+      name: string;
+      filters: {
+        [key: string]: string;
+      };
+    };
+    SegmentDto: components["schemas"]["CreateSegmentDto"] & {
+      id: string;
     };
   };
   responses: never;
@@ -168,6 +200,66 @@ export interface operations {
   };
   /** Export invitations CSV */
   exportInvitations: {
+    responses: {
+      /** @description CSV data */
+      200: {
+        content: {
+          "text/csv": string;
+        };
+      };
+    };
+  };
+  /** Search audience */
+  searchAudience: {
+    parameters: {
+      query?: {
+        attr?: string;
+        value?: string;
+      };
+    };
+    responses: {
+      /** @description Array of participants */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ParticipantDto"][];
+        };
+      };
+    };
+  };
+  /** List segments */
+  listSegments: {
+    responses: {
+      /** @description Array of segments */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SegmentDto"][];
+        };
+      };
+    };
+  };
+  /** Create segment */
+  createSegment: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateSegmentDto"];
+      };
+    };
+    responses: {
+      /** @description Segment created */
+      201: {
+        content: {
+          "application/json": components["schemas"]["SegmentDto"];
+        };
+      };
+    };
+  };
+  /** Export segment CSV */
+  exportSegment: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
     responses: {
       /** @description CSV data */
       200: {

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -107,6 +107,74 @@ paths:
             text/csv:
               schema:
                 type: string
+  /api/audience:
+    get:
+      summary: Search audience
+      operationId: searchAudience
+      parameters:
+        - name: attr
+          in: query
+          schema:
+            type: string
+        - name: value
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Array of participants
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ParticipantDto'
+  /api/segments:
+    get:
+      summary: List segments
+      operationId: listSegments
+      responses:
+        '200':
+          description: Array of segments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SegmentDto'
+    post:
+      summary: Create segment
+      operationId: createSegment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSegmentDto'
+      responses:
+        '201':
+          description: Segment created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SegmentDto'
+  /api/segments/{id}/export:
+    get:
+      summary: Export segment CSV
+      operationId: exportSegment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: CSV data
+          content:
+            text/csv:
+              schema:
+                type: string
 components:
   schemas:
     SubscriptionKeysDto:
@@ -165,3 +233,35 @@ components:
       properties:
         launched:
           type: number
+    ParticipantDto:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+        prescreen:
+          type: object
+          additionalProperties:
+            type: string
+    CreateSegmentDto:
+      type: object
+      required: [name, filters]
+      properties:
+        name:
+          type: string
+        filters:
+          type: object
+          additionalProperties:
+            type: string
+    SegmentDto:
+      allOf:
+        - $ref: '#/components/schemas/CreateSegmentDto'
+        - type: object
+          required: [id]
+          properties:
+            id:
+              type: string

--- a/services/api/src/app.module.ts
+++ b/services/api/src/app.module.ts
@@ -3,8 +3,15 @@ import { SubscriptionsModule } from './subscriptions/subscriptions.module';
 import { StudiesModule } from './studies/studies.module';
 import { InvitationsModule } from './invitations/invitations.module';
 import { ExportModule } from './export/export.module';
+import { AudienceModule } from './audience/audience.module';
 
 @Module({
-  imports: [SubscriptionsModule, StudiesModule, InvitationsModule, ExportModule],
+  imports: [
+    SubscriptionsModule,
+    StudiesModule,
+    InvitationsModule,
+    ExportModule,
+    AudienceModule,
+  ],
 })
 export class AppModule {}

--- a/services/api/src/audience/audience.controller.ts
+++ b/services/api/src/audience/audience.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Get, Header, Param, Post, Query } from '@nestjs/common';
+import { AudienceService } from './audience.service';
+import { ApiTags } from '@nestjs/swagger';
+import { CreateSegmentDto, SegmentDto, ParticipantDto } from './dto/create-segment.dto';
+
+@ApiTags('audience')
+@Controller()
+export class AudienceController {
+  constructor(private readonly service: AudienceService) {}
+
+  @Get('audience')
+  search(@Query() query: Record<string, string>): ParticipantDto[] {
+    const { attr, value, ...rest } = query;
+    const filters = attr && value ? { [attr]: value, ...rest } : query;
+    return this.service.search(filters);
+  }
+
+  @Get('segments')
+  listSegments(): SegmentDto[] {
+    return this.service.listSegments();
+  }
+
+  @Post('segments')
+  createSegment(@Body() dto: CreateSegmentDto): SegmentDto {
+    return this.service.createSegment(dto);
+  }
+
+  @Get('segments/:id/export')
+  @Header('Content-Type', 'text/csv')
+  exportSegment(@Param('id') id: string): string {
+    return this.service.exportSegment(id);
+  }
+}

--- a/services/api/src/audience/audience.module.ts
+++ b/services/api/src/audience/audience.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AudienceController } from './audience.controller';
+import { AudienceService } from './audience.service';
+
+@Module({
+  controllers: [AudienceController],
+  providers: [AudienceService],
+})
+export class AudienceModule {}

--- a/services/api/src/audience/audience.service.ts
+++ b/services/api/src/audience/audience.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateSegmentDto, SegmentDto, ParticipantDto } from './dto/create-segment.dto';
+import { randomUUID } from 'crypto';
+
+interface Filters {
+  [key: string]: string;
+}
+
+@Injectable()
+export class AudienceService {
+  private participants: ParticipantDto[] = [
+    {
+      id: '1',
+      attributes: { age: '25', city: 'NY' },
+      prescreen: { smoker: 'no', pets: 'yes' },
+    },
+    {
+      id: '2',
+      attributes: { age: '30', city: 'LA' },
+      prescreen: { smoker: 'yes', pets: 'no' },
+    },
+    {
+      id: '3',
+      attributes: { age: '22', city: 'NY' },
+      prescreen: { smoker: 'no', pets: 'no' },
+    },
+  ];
+
+  private segments: SegmentDto[] = [];
+
+  search(filters: Filters): ParticipantDto[] {
+    return this.participants.filter((p) =>
+      Object.entries(filters).every(
+        ([k, v]) => p.attributes[k] === v || p.prescreen[k] === v,
+      ),
+    );
+  }
+
+  listSegments(): SegmentDto[] {
+    return this.segments;
+  }
+
+  createSegment(dto: CreateSegmentDto): SegmentDto {
+    const segment: SegmentDto = { id: randomUUID(), ...dto };
+    this.segments.push(segment);
+    return segment;
+  }
+
+  exportSegment(id: string): string {
+    const segment = this.segments.find((s) => s.id === id);
+    if (!segment) throw new NotFoundException('Segment not found');
+    const people = this.search(segment.filters);
+    if (people.length === 0) return '';
+    const headers = Array.from(
+      new Set(
+        people.flatMap((p) => [
+          'id',
+          ...Object.keys(p.attributes),
+          ...Object.keys(p.prescreen),
+        ]),
+      ),
+    );
+    const rows = [headers.join(',')];
+    for (const person of people) {
+      rows.push(
+        headers
+          .map((h) => {
+            if (h === 'id') return person.id;
+            return person.attributes[h] ?? person.prescreen[h] ?? '';
+          })
+          .join(','),
+      );
+    }
+    return rows.join('\n');
+  }
+}

--- a/services/api/src/audience/dto/create-segment.dto.ts
+++ b/services/api/src/audience/dto/create-segment.dto.ts
@@ -1,0 +1,19 @@
+import { IsObject, IsString } from 'class-validator';
+
+export class CreateSegmentDto {
+  @IsString()
+  name: string;
+
+  @IsObject()
+  filters: Record<string, string>;
+}
+
+export class SegmentDto extends CreateSegmentDto {
+  id: string;
+}
+
+export interface ParticipantDto {
+  id: string;
+  attributes: Record<string, string>;
+  prescreen: Record<string, string>;
+}


### PR DESCRIPTION
## Summary
- add Audience module with filtering, segment saving and CSV export
- document audience and segment endpoints in OpenAPI
- regenerate shared API types

## Testing
- `npm run -w packages/shared generate`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_689c9996d83883309788c4fe9bad0a14