### PR TITLE
feat(admin): study form (create/edit) with targeting & quotas

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MAR Admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "mar-admin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext .ts,.tsx",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck"
+  },
+  "dependencies": {
+    "@tanstack/react-router": "^1.6.3",
+    "@mar/shared": "*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.25",
+    "@types/react-dom": "^18.2.11",
+    "@typescript-eslint/eslint-plugin": "^6.7.4",
+    "@typescript-eslint/parser": "^6.7.4",
+    "eslint": "^8.53.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.0.3",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.1.0",
+    "vite-plugin-pwa": "^0.16.4"
+  }
+}

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -1,0 +1,38 @@
+import type { components } from '@mar/shared';
+
+type CreateStudyDto = components['schemas']['CreateStudyDto'];
+type StudyDto = components['schemas']['StudyDto'];
+
+const jsonHeaders = { 'Content-Type': 'application/json' };
+
+export async function listStudies(): Promise<StudyDto[]> {
+  const res = await fetch('/api/studies');
+  if (!res.ok) throw new Error('Failed to list studies');
+  return res.json();
+}
+
+export async function getStudy(id: string): Promise<StudyDto> {
+  const res = await fetch(`/api/studies/${id}`);
+  if (!res.ok) throw new Error('Failed to get study');
+  return res.json();
+}
+
+export async function createStudy(data: CreateStudyDto): Promise<StudyDto> {
+  const res = await fetch('/api/studies', {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create study');
+  return res.json();
+}
+
+export async function updateStudy(id: string, data: CreateStudyDto): Promise<StudyDto> {
+  const res = await fetch(`/api/studies/${id}`, {
+    method: 'PUT',
+    headers: jsonHeaders,
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to update study');
+  return res.json();
+}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from '@tanstack/react-router';
+import { router } from './router';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);

--- a/apps/admin/src/router.tsx
+++ b/apps/admin/src/router.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+  Router,
+  Route,
+  RootRoute,
+  Outlet,
+  Link,
+  createHashHistory,
+} from '@tanstack/react-router';
+import StudiesList from './routes/studies';
+import NewStudy from './routes/studies/NewStudy';
+import EditStudy from './routes/studies/EditStudy';
+
+const rootRoute = new RootRoute({
+  component: () => (
+    <div>
+      <nav style={{ display: 'flex', gap: '1rem' }}>
+        <Link to="/studies">Исследования</Link>
+      </nav>
+      <Outlet />
+    </div>
+  ),
+});
+
+const studiesRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/studies',
+  component: StudiesList,
+});
+
+const newStudyRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/studies/new',
+  component: NewStudy,
+});
+
+const editStudyRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/studies/$id/edit',
+  component: EditStudy,
+});
+
+const routeTree = rootRoute.addChildren([
+  studiesRoute,
+  newStudyRoute,
+  editStudyRoute,
+]);
+
+export const router = new Router({
+  routeTree,
+  history: createHashHistory(),
+  basepath: '/admin',
+});
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/apps/admin/src/routes/studies/EditStudy.tsx
+++ b/apps/admin/src/routes/studies/EditStudy.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import StudyForm from './StudyForm';
+import { getStudy, updateStudy } from '../../api/client';
+import type { components } from '@mar/shared';
+
+type CreateStudyDto = components['schemas']['CreateStudyDto'];
+
+export default function EditStudy() {
+  const navigate = useNavigate();
+  const { id } = useParams({ from: '/studies/$id/edit' });
+  const [initial, setInitial] = useState<CreateStudyDto | null>(null);
+
+  useEffect(() => {
+    getStudy(id).then(setInitial);
+  }, [id]);
+
+  const handleSubmit = async (data: CreateStudyDto) => {
+    await updateStudy(id, data);
+    navigate({ to: '/studies' });
+  };
+
+  if (!initial) return <div>Loading...</div>;
+
+  return <StudyForm initial={initial} onSubmit={handleSubmit} />;
+}

--- a/apps/admin/src/routes/studies/NewStudy.tsx
+++ b/apps/admin/src/routes/studies/NewStudy.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import StudyForm from './StudyForm';
+import { createStudy } from '../../api/client';
+import type { components } from '@mar/shared';
+
+type CreateStudyDto = components['schemas']['CreateStudyDto'];
+
+export default function NewStudy() {
+  const navigate = useNavigate();
+
+  const handleSubmit = async (data: CreateStudyDto) => {
+    await createStudy(data);
+    navigate({ to: '/studies' });
+  };
+
+  return <StudyForm onSubmit={handleSubmit} />;
+}

--- a/apps/admin/src/routes/studies/StudyForm.tsx
+++ b/apps/admin/src/routes/studies/StudyForm.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import type { components } from '@mar/shared';
+
+type CreateStudyDto = components['schemas']['CreateStudyDto'];
+
+interface Props {
+  initial?: Partial<CreateStudyDto>;
+  onSubmit: (data: CreateStudyDto) => void | Promise<void>;
+}
+
+const toInputDateTime = (value?: string) =>
+  value ? value.slice(0, 16) : '';
+
+export default function StudyForm({ initial = {}, onSubmit }: Props) {
+  const [title, setTitle] = useState(initial.title ?? '');
+  const [link, setLink] = useState(initial.link ?? '');
+  const [description, setDescription] = useState(initial.description ?? '');
+  const [durationMin, setDurationMin] = useState(
+    initial.durationMin?.toString() ?? ''
+  );
+  const [rewardCents, setRewardCents] = useState(
+    initial.rewardCents?.toString() ?? ''
+  );
+  const [deadlineAt, setDeadlineAt] = useState(toInputDateTime(initial.deadlineAt));
+  const [targeting, setTargeting] = useState(
+    initial.targeting ? JSON.stringify(initial.targeting, null, 2) : ''
+  );
+  const [quotas, setQuotas] = useState(
+    initial.quotas ? JSON.stringify(initial.quotas, null, 2) : ''
+  );
+  const [preview, setPreview] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const payload: CreateStudyDto = {
+        title,
+        link,
+        description: description || undefined,
+        durationMin: durationMin ? Number(durationMin) : undefined,
+        rewardCents: rewardCents ? Number(rewardCents) : undefined,
+        deadlineAt: deadlineAt ? new Date(deadlineAt).toISOString() : undefined,
+        targeting: targeting ? JSON.parse(targeting) : undefined,
+        quotas: quotas ? JSON.parse(quotas) : undefined,
+      };
+      onSubmit(payload);
+    } catch (err) {
+      setError('Invalid JSON');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      {error && <div style={{ color: 'red' }}>{error}</div>}
+      <label>
+        Title*
+        <input value={title} onChange={(e) => setTitle(e.target.value)} required />
+      </label>
+      <label>
+        Link*
+        <input value={link} onChange={(e) => setLink(e.target.value)} required />
+      </label>
+      <label>
+        Description
+        <textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+      </label>
+      <label>
+        Duration (min)
+        <input
+          type="number"
+          value={durationMin}
+          onChange={(e) => setDurationMin(e.target.value)}
+        />
+      </label>
+      <label>
+        Reward (cents)
+        <input
+          type="number"
+          value={rewardCents}
+          onChange={(e) => setRewardCents(e.target.value)}
+        />
+      </label>
+      <label>
+        Deadline
+        <input
+          type="datetime-local"
+          value={deadlineAt}
+          onChange={(e) => setDeadlineAt(e.target.value)}
+        />
+      </label>
+      <label>
+        Targeting (JSON)
+        <textarea value={targeting} onChange={(e) => setTargeting(e.target.value)} />
+      </label>
+      <label>
+        Quotas (JSON)
+        <textarea value={quotas} onChange={(e) => setQuotas(e.target.value)} />
+      </label>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <button type="submit">Сохранить</button>
+        <button type="button" onClick={() => setPreview((p) => !p)}>
+          Предпросмотр
+        </button>
+      </div>
+      {preview && (
+        <div style={{ border: '1px solid #ccc', padding: '1rem' }}>
+          <h3>{title}</h3>
+          <p>
+            <a href={link} target="_blank" rel="noreferrer">
+              {link}
+            </a>
+          </p>
+          {durationMin && <p>Длительность: {durationMin} мин</p>}
+          {rewardCents && <p>Вознаграждение: {rewardCents}¢</p>}
+          {deadlineAt && <p>Дедлайн: {deadlineAt}</p>}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/apps/admin/src/routes/studies/index.tsx
+++ b/apps/admin/src/routes/studies/index.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { listStudies } from '../../api/client';
+import type { components } from '@mar/shared';
+
+type StudyDto = components['schemas']['StudyDto'];
+
+export default function StudiesList() {
+  const [studies, setStudies] = useState<StudyDto[]>([]);
+
+  useEffect(() => {
+    listStudies().then(setStudies);
+  }, []);
+
+  return (
+    <div>
+      <h2>Исследования</h2>
+      <Link to="/studies/new">Создать</Link>
+      <ul>
+        {studies.map((s) => (
+          <li key={s.id}>
+            {s.title} – (
+            <Link to="/studies/$id/edit" params={{ id: s.id }}>
+              Редактировать
+            </Link>
+            )
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/admin/src/vite-env.d.ts
+++ b/apps/admin/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/admin/',
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,31 @@
         "services/*"
       ]
     },
+    "apps/admin": {
+      "name": "mar-admin",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mar/shared": "*",
+        "@tanstack/react-router": "^1.6.3",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.25",
+        "@types/react-dom": "^18.2.11",
+        "@typescript-eslint/eslint-plugin": "^6.7.4",
+        "@typescript-eslint/parser": "^6.7.4",
+        "@vitejs/plugin-react": "^4.1.0",
+        "eslint": "^8.53.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "prettier": "^3.0.3",
+        "typescript": "^5.2.2",
+        "vite": "^5.0.0",
+        "vite-plugin-pwa": "^0.16.4"
+      }
+    },
     "apps/web": {
       "name": "mar-web",
       "version": "0.1.0",
@@ -6671,6 +6696,10 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/mar-admin": {
+      "resolved": "apps/admin",
+      "link": true
     },
     "node_modules/mar-web": {
       "resolved": "apps/web",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "workspaces": ["apps/*", "packages/*", "services/*"],
   "scripts": {
-    "typecheck": "npm run typecheck -ws"
+    "typecheck": "npm run typecheck -ws",
+    "gen:api-types": "npm run generate -w @mar/shared"
   }
 }

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -3,6 +3,7 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
   "/api/subscriptions": {
     /** Create subscription */
@@ -21,6 +22,8 @@ export interface paths {
   "/api/studies/{id}": {
     /** Get study by id */
     get: operations["getStudy"];
+    /** Update study */
+    put: operations["updateStudy"];
   };
   "/api/invitations/launch": {
     /** Launch invitations */
@@ -39,9 +42,9 @@ export interface paths {
     get: operations["exportAudience"];
   };
   "/api/audience/segments": {
-    /** List segments */
+    /** List saved segments */
     get: operations["listSegments"];
-    /** Create segment */
+    /** Create new segment */
     post: operations["createSegment"];
   };
   "/api/profile": {
@@ -65,30 +68,41 @@ export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
     SubscriptionKeysDto: {
-      p256dh: string;
-      auth: string;
+      p256dh?: string;
+      auth?: string;
     };
     CreateSubscriptionDto: {
-      endpoint: string;
-      keys: components["schemas"]["SubscriptionKeysDto"];
+      endpoint?: string;
+      keys?: components["schemas"]["SubscriptionKeysDto"];
     };
     SubscriptionDto: components["schemas"]["CreateSubscriptionDto"] & {
-      id: string;
+      id?: string;
     };
     CreateStudyDto: {
       title: string;
+      link: string;
       description?: string;
+      durationMin?: number;
+      rewardCents?: number;
+      /** Format: date-time */
+      deadlineAt?: string;
+      targeting?: {
+        [key: string]: unknown;
+      };
+      quotas?: {
+        [key: string]: unknown;
+      };
     };
     StudyDto: components["schemas"]["CreateStudyDto"] & {
       id: string;
     };
     LaunchInvitationDto: {
-      studyId: string;
+      studyId?: string;
       segment?: string;
       quota?: number;
     };
     LaunchInvitationResponseDto: {
-      launched: number;
+      launched?: number;
     };
     AudienceFilterDto: {
       q?: string;
@@ -99,27 +113,27 @@ export interface components {
       segmentId?: string;
     };
     AudienceDto: {
-      id: string;
-      email: string;
-      name: string;
-      age: number;
-      gender: string;
-      city: string;
+      id?: string;
+      email?: string;
+      name?: string;
+      age?: number;
+      gender?: string;
+      city?: string;
     };
     CreateSegmentDto: {
-      name: string;
-      filter: components["schemas"]["AudienceFilterDto"];
+      name?: string;
+      filter?: components["schemas"]["AudienceFilterDto"];
     };
     SegmentDto: components["schemas"]["CreateSegmentDto"] & {
-      id: string;
+      id?: string;
     };
     ProfileDto: {
-      name: string;
-      age: number;
-      gender: string;
-      city: string;
-      profession: string;
-      contacts: string;
+      name?: string;
+      age?: number;
+      gender?: string;
+      city?: string;
+      profession?: string;
+      contacts?: string;
     };
     UpdateProfileDto: {
       name?: string;
@@ -130,12 +144,12 @@ export interface components {
       contacts?: string;
     };
     PrescreenBlockDto: {
-      id: string;
-      question: string;
-      answer: string;
+      id?: string;
+      question?: string;
+      answer?: string;
     };
     UpdatePrescreenBlockDto: {
-      answer: string;
+      answer?: string;
     };
   };
   responses: never;
@@ -150,6 +164,7 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
+
   /** Create subscription */
   createSubscription: {
     requestBody: {
@@ -223,6 +238,27 @@ export interface operations {
       };
     };
   };
+  /** Update study */
+  updateStudy: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateStudyDto"];
+      };
+    };
+    responses: {
+      /** @description Study */
+      200: {
+        content: {
+          "application/json": components["schemas"]["StudyDto"];
+        };
+      };
+    };
+  };
   /** Launch invitations */
   launchInvitations: {
     requestBody: {
@@ -242,7 +278,7 @@ export interface operations {
   /** Export invitations CSV */
   exportInvitations: {
     responses: {
-      /** @description CSV data */
+      /** @description CSV */
       200: {
         content: {
           "text/csv": string;
@@ -263,7 +299,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Array of audience profiles */
+      /** @description OK */
       200: {
         content: {
           "application/json": components["schemas"]["AudienceDto"][];
@@ -275,16 +311,11 @@ export interface operations {
   exportAudience: {
     parameters: {
       query?: {
-        q?: string;
-        city?: string;
-        gender?: string;
-        prescreenQuestion?: string;
-        prescreenAnswer?: string;
-        segmentId?: string;
+        segmentId?: string | null;
       };
     };
     responses: {
-      /** @description CSV data */
+      /** @description CSV */
       200: {
         content: {
           "text/csv": string;
@@ -292,10 +323,10 @@ export interface operations {
       };
     };
   };
-  /** List segments */
+  /** List saved segments */
   listSegments: {
     responses: {
-      /** @description Array of segments */
+      /** @description OK */
       200: {
         content: {
           "application/json": components["schemas"]["SegmentDto"][];
@@ -303,7 +334,7 @@ export interface operations {
       };
     };
   };
-  /** Create segment */
+  /** Create new segment */
   createSegment: {
     requestBody: {
       content: {

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -81,6 +81,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StudyDto'
+    put:
+      operationId: updateStudy
+      summary: Update study
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateStudyDto'
+      responses:
+        '200':
+          description: Study
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyDto'
 
   /api/invitations/launch:
     post:
@@ -280,14 +301,28 @@ components:
 
     CreateStudyDto:
       type: object
+      required: [title, link]
       properties:
         title: { type: string }
+        link: { type: string }
         description: { type: string }
+        durationMin: { type: integer }
+        rewardCents: { type: integer }
+        deadlineAt:
+          type: string
+          format: date-time
+        targeting:
+          type: object
+          additionalProperties: true
+        quotas:
+          type: object
+          additionalProperties: true
 
     StudyDto:
       allOf:
         - $ref: '#/components/schemas/CreateStudyDto'
         - type: object
+          required: [id]
           properties:
             id: { type: string }
 

--- a/services/api/src/app.controller.ts
+++ b/services/api/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHealth() {
+    return this.appService.getHealth();
+  }
+}

--- a/services/api/src/app.module.ts
+++ b/services/api/src/app.module.ts
@@ -6,11 +6,7 @@ import { ProfileModule } from './profile/profile.module';
 import { PrescreenModule } from './prescreen/prescreen.module';
 
 @Module({
-  imports: [
-    AudienceModule,
-    ProfileModule,
-    PrescreenModule,
-  ],
+  imports: [AudienceModule, ProfileModule, PrescreenModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/services/api/src/app.service.ts
+++ b/services/api/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHealth() {
+    return { status: 'ok' };
+  }
+}


### PR DESCRIPTION
## Summary
- add admin client and routes for creating and editing studies with targeting and quotas
- expand API spec with study fields and generate shared types

## Testing
- `npm run typecheck`
- `npm run build -w apps/admin`
- `npm run build -w services/api`
- `npm run build -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_689ca90f64dc83309d4f7d247c4d37e5