### PR TITLE
docs: add QA test plan and lighthouse CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
                   "assertions": {
                     "categories:pwa": ["error", { "minScore": 0.9 }],
                     "categories:performance": ["error", { "minScore": 0.9 }],
-                    "categories:best-practices": ["error", { "minScore": 0.9 }]
+                    "categories:best-practices": ["error", { "minScore": 0.9 }],
+                    "categories:accessibility": ["error", { "minScore": 0.9 }]
                   }
                 }
               }

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,40 @@
+name: Lighthouse
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build -w apps/web
+      - name: Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v10
+        env:
+          LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
+        with:
+          config: |
+            {
+              "ci": {
+                "collect": { "staticDistDir": "apps/web/dist" },
+                "assert": {
+                  "assertions": {
+                    "categories:pwa": ["error", { "minScore": 0.9 }],
+                    "categories:performance": ["error", { "minScore": 0.9 }],
+                    "categories:best-practices": ["error", { "minScore": 0.9 }],
+                    "categories:accessibility": ["error", { "minScore": 0.9 }]
+                  }
+                }
+              }
+            }
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,35 @@
+# Test Plan
+
+## Platforms
+- [ ] iOS (Safari PWA)
+- [ ] Android (Chrome)
+- [ ] Desktop (Chrome/Edge)
+
+## Push Notifications
+### Subscription
+- [ ] Request notification permission
+- [ ] Register Service Worker and subscribe
+- [ ] Persist subscription server-side
+
+### Open from Push
+- [ ] Receive push in foreground and background
+- [ ] Clicking notification opens target deep link
+
+## Campaigns
+- [ ] Create campaign with content and segment
+- [ ] Launch campaign
+- [ ] Delivery events appear in dashboard
+
+## CSV Export
+- [ ] Export campaign results to CSV
+- [ ] File has expected columns and data
+
+## Offline Mode
+- [ ] App shell loads without network
+- [ ] Queued actions sync after reconnect
+
+## Lighthouse
+- [ ] Performance ≥ 90
+- [ ] PWA ≥ 90
+- [ ] Best Practices ≥ 90
+- [ ] Accessibility ≥ 90


### PR DESCRIPTION
## Summary
- document cross-platform QA checks and push/campaign scenarios in new test plan
- add standalone Lighthouse workflow and enforce accessibility >= 90 in existing CI

## Testing
- `npm run lint -w apps/web`
- `npm test -w apps/web`
- `npm run build -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_689cb3f1a1d08330baed3a33ff4f444f