### PR TITLE
fix: deploy PWA to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,28 @@
+name: Deploy PWA to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build --workspace apps/web
+      - run: cp apps/web/dist/index.html apps/web/dist/404.html
+      - run: touch apps/web/dist/.nojekyll
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: apps/web/dist
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v4

--- a/apps/web/src/pages/Profile.tsx
+++ b/apps/web/src/pages/Profile.tsx
@@ -60,9 +60,9 @@ export default function ProfilePage() {
           givenAt: new Date().toISOString(),
         }),
       });
-      setConsentStatus('Согласие сохранено');
+      setConsentStatus(t('common.saved'));
     } catch {
-      setConsentStatus('Ошибка сохранения');
+      setConsentStatus(t('common.error'));
     }
   }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
+  base: '/mar-pwa/',
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- configure Vite for GitHub Pages path
- translate consent status and clean profile page
- add GitHub Pages workflow with build and deploy jobs

## Testing
- `npm test --workspace apps/web`
- `npm run build --workspace apps/web`


------
https://chatgpt.com/codex/tasks/task_e_689cb8312da88330a23fc1c3ad470db6