### PR TITLE
ci: fix invalid if expressions in deploy-api (secrets != '')

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           node-version: 20
       - name: Deploy to Render
-        if: ${{ secrets.RENDER_API_TOKEN && secrets.RENDER_SERVICE_ID }}
+        if: ${{ secrets.RENDER_API_TOKEN != '' && secrets.RENDER_SERVICE_ID != '' }}
         env:
           RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
@@ -115,7 +115,7 @@ jobs:
           curl -X POST https://api.render.com/deploy/srv-$RENDER_SERVICE_ID \
             -H "Authorization: Bearer $RENDER_API_TOKEN"
       - name: Deploy to Vercel
-        if: ${{ secrets.VERCEL_TOKEN && secrets.VERCEL_ORG_ID && secrets.VERCEL_PROJECT_ID }}
+        if: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- fix invalid if expressions in deploy-api (secrets != '')

## Testing
- `python - <<'PY'\nimport yaml, sys\nyaml.safe_load(open('.github/workflows/ci.yml'))\nprint('YAML parsed')\nPY`
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`

## Diff
```
Deploy to Render:
- if: ${{ secrets.RENDER_API_TOKEN && secrets.RENDER_SERVICE_ID }}
+ if: ${{ secrets.RENDER_API_TOKEN != '' && secrets.RENDER_SERVICE_ID != '' }}

Deploy to Vercel:
- if: ${{ secrets.VERCEL_TOKEN && secrets.VERCEL_ORG_ID && secrets.VERCEL_PROJECT_ID }}
+ if: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
```

------
https://chatgpt.com/codex/tasks/task_e_689db66edf148330959d2f1fa2a5a75a