### PR TITLE
style(web): import ./index.css; ensure Tailwind content & PostCSS (or fallback CSS)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,5 @@
+html,body,#root{height:100%}
+*{box-sizing:border-box}
+body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif}
+a{color:#2563eb;text-decoration:none}
+a:hover{text-decoration:underline}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,4 @@
+import './index.css';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from '@tanstack/react-router';


### PR DESCRIPTION
## Summary
- import index.css in React entry
- add baseline CSS when Tailwind is absent

## Testing
- `npm test -w apps/web`
- `npm run lint -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_689dc8248cd083308c30b1d8ab969a4b