### PR TITLE
build: deploy admin app on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,9 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build -w apps/web
+      - run: npm run build -w apps/admin
+      - run: mkdir -p apps/web/dist/admin
+      - run: rsync -a --delete apps/admin/dist/ apps/web/dist/admin/
       - run: cp apps/web/dist/index.html apps/web/dist/404.html
       - run: touch apps/web/dist/.nojekyll
       - uses: actions/upload-pages-artifact@v3

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -1,0 +1,5 @@
+html,body,#root{height:100%}
+*{box-sizing:border-box}
+body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif}
+a{color:#2563eb;text-decoration:none}
+a:hover{text-decoration:underline}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,3 +1,4 @@
+import './index.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from '@tanstack/react-router';

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/admin/',
+  base: '/mar-pwa/admin/',
 });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -25,6 +25,7 @@ const rootRoute = new RootRoute({
         <Link to="/studies">{t('sections.studies')}</Link>
         <Link to="/rewards">{t('sections.rewards')}</Link>
         <Link to="/support">{t('sections.support')}</Link>
+        <a href="/mar-pwa/admin/">Admin</a>
       </nav>
       <Outlet />
     </div>


### PR DESCRIPTION
## Summary
- configure admin base path and styles
- copy admin build into web dist for Pages deployment and expose link in web nav

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run lint -w apps/web`
- `npm run lint -w apps/admin` *(fails: ESLint configuration file missing)*

------
https://chatgpt.com/codex/tasks/task_e_689dc9ec0d448330a781dd770c731f7c