### PR TITLE
ci(pages): pass VITE_API_URL to build from repo variables

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      VITE_API_URL: ${{ vars.VITE_API_URL }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -26,8 +28,7 @@ jobs:
       - run: npm ci
       - run: npm run build -w apps/web
       - run: npm run build -w apps/admin
-      - run: mkdir -p apps/web/dist/admin
-      - run: rsync -a --delete apps/admin/dist/ apps/web/dist/admin/
+      - run: mkdir -p apps/web/dist/admin && rsync -a --delete apps/admin/dist/ apps/web/dist/admin/
       - run: cp apps/web/dist/index.html apps/web/dist/404.html
       - run: touch apps/web/dist/.nojekyll
       - uses: actions/upload-pages-artifact@v3

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -6,22 +6,24 @@ type CampaignCreateDto = components['schemas']['CampaignCreateDto'];
 type CampaignDto = components['schemas']['CampaignDto'];
 type NotificationEventDto = components['schemas']['NotificationEventDto'];
 
+const API = (import.meta.env.VITE_API_URL ?? '').replace(/\/$/, '');
 const jsonHeaders = { 'Content-Type': 'application/json' };
+const api = (p: string) => `${API}${p}`;
 
 export async function listStudies(): Promise<StudyDto[]> {
-  const res = await fetch('/api/studies');
+  const res = await fetch(api('/api/studies'));
   if (!res.ok) throw new Error('Failed to list studies');
   return res.json();
 }
 
 export async function getStudy(id: string): Promise<StudyDto> {
-  const res = await fetch(`/api/studies/${id}`);
+  const res = await fetch(api(`/api/studies/${id}`));
   if (!res.ok) throw new Error('Failed to get study');
   return res.json();
 }
 
 export async function createStudy(data: CreateStudyDto): Promise<StudyDto> {
-  const res = await fetch('/api/studies', {
+  const res = await fetch(api('/api/studies'), {
     method: 'POST',
     headers: jsonHeaders,
     body: JSON.stringify(data),
@@ -31,7 +33,7 @@ export async function createStudy(data: CreateStudyDto): Promise<StudyDto> {
 }
 
 export async function updateStudy(id: string, data: CreateStudyDto): Promise<StudyDto> {
-  const res = await fetch(`/api/studies/${id}`, {
+  const res = await fetch(api(`/api/studies/${id}`), {
     method: 'PUT',
     headers: jsonHeaders,
     body: JSON.stringify(data),
@@ -41,13 +43,13 @@ export async function updateStudy(id: string, data: CreateStudyDto): Promise<Stu
 }
 
 export async function listCampaigns(): Promise<CampaignDto[]> {
-  const res = await fetch('/api/campaigns');
+  const res = await fetch(api('/api/campaigns'));
   if (!res.ok) throw new Error('Failed to list campaigns');
   return res.json();
 }
 
 export async function createCampaign(data: CampaignCreateDto): Promise<CampaignDto> {
-  const res = await fetch('/api/campaigns', {
+  const res = await fetch(api('/api/campaigns'), {
     method: 'POST',
     headers: jsonHeaders,
     body: JSON.stringify(data),
@@ -57,25 +59,25 @@ export async function createCampaign(data: CampaignCreateDto): Promise<CampaignD
 }
 
 export async function getCampaign(id: string): Promise<CampaignDto> {
-  const res = await fetch(`/api/campaigns/${id}`);
+  const res = await fetch(api(`/api/campaigns/${id}`));
   if (!res.ok) throw new Error('Failed to get campaign');
   return res.json();
 }
 
 export async function launchCampaign(id: string): Promise<{ launched: number }> {
-  const res = await fetch(`/api/campaigns/${id}`, { method: 'POST' });
+  const res = await fetch(api(`/api/campaigns/${id}`), { method: 'POST' });
   if (!res.ok) throw new Error('Failed to launch campaign');
   return res.json();
 }
 
 export async function stopCampaign(id: string): Promise<{ stopped: boolean }> {
-  const res = await fetch(`/api/campaigns/${id}`, { method: 'PUT' });
+  const res = await fetch(api(`/api/campaigns/${id}`), { method: 'PUT' });
   if (!res.ok) throw new Error('Failed to stop campaign');
   return res.json();
 }
 
 export async function listCampaignEvents(id: string): Promise<NotificationEventDto[]> {
-  const res = await fetch(`/api/campaigns/${id}/events`);
+  const res = await fetch(api(`/api/campaigns/${id}/events`));
   if (!res.ok) throw new Error('Failed to list events');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- inject VITE_API_URL into GitHub Pages build via repo variables
- use VITE_API_URL for admin API requests

## Testing
- `npm test -w apps/admin`
- `npm test -w apps/web`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dcc2f11348330a1e40da3db71eb1f